### PR TITLE
Added support for creating multi indexer cluster

### DIFF
--- a/roles/splunk_monitor/tasks/setup_multisite.yml
+++ b/roles/splunk_monitor/tasks/setup_multisite.yml
@@ -3,21 +3,17 @@
   vars:
     splunk_instance_address: "{{ splunk.multisite_master }}"
 
-- name: Convert Extrenal Cluster Master Name into Internal URI
-  set_fact:
-      multisite_master_uri: "{{ cert_prefix }}://{{ splunk.multisite_master }}:{{ splunk.svc_port }}"
-#INFRA-38882: Update
 - name: Setup SH - Multisite
-  command: "{{ splunk.exec }} edit cluster-config -mode searchhead -master_uri {{ multisite_master_uri }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.pass4SymmKey }}"
+  command: "{{ splunk.exec }} add cluster-manager {{ cert_prefix }}://{{ item }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.pass4SymmKey }} -site {{ splunk.site }}"
+  with_items: "{{ splunk.multisite_master.split(',') }}"
   become: yes
   become_user: "{{ splunk.user }}"
   register: set_new_master
-  until: set_new_master.rc == 0 or (set_new_master.rc != 0 and "Cannot edit this searchhead. Use 'splunk edit cluster-master' to edit information for this searchhead." in set_new_master.stderr) or (set_new_master.rc != 0 and "Cannot edit this searchhead. Use 'splunk edit cluster-manager' to edit information for this searchhead." in set_new_master.stderr)
-  failed_when: (set_new_master.rc != 0 and "Cannot edit this searchhead. Use 'splunk edit cluster-master' to edit information for this searchhead." not in set_new_master.stderr) or (set_new_master.rc != 0 and "Cannot edit this searchhead. Use 'splunk edit cluster-manager' to edit information for this searchhead." not in set_new_master.stderr)
+  until: set_new_master.rc == 0 or (set_new_master.rc != 0 and "Cannot re-add this manager. It already exists in the conf." in set_new_master.stderr)
+  failed_when: set_new_master.rc != 0 and ("Cannot re-add this manager. It already exists in the conf." not in set_new_master.stderr )
   changed_when: set_new_master.rc == 0
   retries: "{{ retry_num }}"
   delay: "{{ retry_delay }}"
-  ignore_errors: yes
   notify:
     - Restart the splunkd service
   no_log: "{{ hide_password }}"
@@ -26,18 +22,3 @@
   meta: flush_handlers
 
 - include_tasks: ../../../roles/splunk_common/tasks/wait_for_splunk_process.yml
-
-- name: Setup SH with Associated Site
-  command: "{{ splunk.exec }} edit cluster-master -old_master_uri {{ multisite_master_uri }} -site {{ splunk.site }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.pass4SymmKey }} -multisite True"
-  become: yes
-  become_user: "{{ splunk.user }}"
-  register: set_associated_site
-  until: set_associated_site.rc == 0 or (set_associated_site.rc == 22 and 'No change in master or secret or site.' in set_associated_site.stderr) or (set_associated_site.rc == 22 and 'No change in manager or secret or site.' in set_associated_site.stderr)
-  changed_when: set_associated_site.rc == 0
-  retries: "{{ retry_num }}"
-  delay: "{{ retry_delay }}"
-  ignore_errors: yes
-  notify:
-    - Restart the splunkd service
-  no_log: "{{ hide_password }}"
-  failed_when: (set_associated_site.rc != 0 and 'No change in master or secret or site.' not in set_associated_site.stderr) or (set_associated_site.rc != 0 and 'No change in manager or secret or site.' not in set_associated_site.stderr)

--- a/roles/splunk_search_head/tasks/setup_multisite.yml
+++ b/roles/splunk_search_head/tasks/setup_multisite.yml
@@ -2,13 +2,15 @@
 - include_tasks: ../../../roles/splunk_common/tasks/wait_for_splunk_instance.yml
   vars:
     splunk_instance_address: "{{ splunk.multisite_master }}"
-    
+
 #this will setup the mode as searchhead in the server.conf and that will allow the Setup SHC -multisite to work as expected.
 - include_tasks: ../../splunk_common/tasks/peer_cluster_master.yml
   when:
     - splunk_indexer_cluster or splunk.multisite_master is defined
     - splunk.set_search_peers is defined
     - splunk.set_search_peers | bool
+
+- include_tasks: ../../../roles/splunk_common/tasks/check_for_required_restarts.yml
 
 - name: Setup SHC - Multisite
   command: "{{ splunk.exec }} add cluster-manager {{ cert_prefix }}://{{ item }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.pass4SymmKey }} -site {{ splunk.site }}"
@@ -21,6 +23,7 @@
   changed_when: set_new_master.rc == 0
   retries: "{{ retry_num }}"
   delay: "{{ retry_delay }}"
+  ignore_errors: yes
   notify:
     - Restart the splunkd service
   no_log: "{{ hide_password }}"

--- a/roles/splunk_search_head/tasks/setup_multisite.yml
+++ b/roles/splunk_search_head/tasks/setup_multisite.yml
@@ -3,22 +3,24 @@
   vars:
     splunk_instance_address: "{{ splunk.multisite_master }}"
     
-#INFRA-38882: Update exec command?
-- name: Convert Extrenal Cluster Master Name into Internal URI
-  set_fact:
-      multisite_master_uri: "{{ cert_prefix }}://{{ splunk.multisite_master }}:{{ splunk.svc_port }}"
+#this will setup the mode as searchhead in the server.conf and that will allow the Setup SHC -multisite to work as expected.
+- include_tasks: ../../splunk_common/tasks/peer_cluster_master.yml
+  when:
+    - splunk_indexer_cluster or splunk.multisite_master is defined
+    - splunk.set_search_peers is defined
+    - splunk.set_search_peers | bool
 
 - name: Setup SHC - Multisite
-  command: "{{ splunk.exec }} edit cluster-config -mode searchhead -master_uri {{ multisite_master_uri }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.pass4SymmKey }}"
+  command: "{{ splunk.exec }} add cluster-manager {{ cert_prefix }}://{{ item }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.pass4SymmKey }} -site {{ splunk.site }}"
+  with_items: "{{ splunk.multisite_master.split(',') }}"
   become: yes
   become_user: "{{ splunk.user }}"
   register: set_new_master
-  until: set_new_master.rc == 0 or (set_new_master.rc != 0 and "Cannot edit this searchhead. Use 'splunk edit cluster-master' to edit information for this searchhead." in set_new_master.stderr) or (set_new_master.rc != 0 and "Cannot edit this searchhead. Use 'splunk edit cluster-manager' to edit information for this searchhead." in set_new_master.stderr)
-  failed_when: set_new_master.rc != 0 and ("Cannot edit this searchhead. Use 'splunk edit cluster-master' to edit information for this searchhead." not in set_new_master.stderr and "Cannot edit this searchhead. Use 'splunk edit cluster-manager' to edit information for this searchhead." not in set_new_master.stderr)
+  until: set_new_master.rc == 0 or (set_new_master.rc != 0 and "Cannot re-add this manager. It already exists in the conf." in set_new_master.stderr)
+  failed_when: set_new_master.rc != 0 and ("Cannot re-add this manager. It already exists in the conf." not in set_new_master.stderr )
   changed_when: set_new_master.rc == 0
   retries: "{{ retry_num }}"
   delay: "{{ retry_delay }}"
-  ignore_errors: yes
   notify:
     - Restart the splunkd service
   no_log: "{{ hide_password }}"
@@ -27,18 +29,3 @@
   meta: flush_handlers
 
 - include_tasks: ../../../roles/splunk_common/tasks/wait_for_splunk_process.yml
-
-- name: Setup SHC with Associated Site
-  command: "{{ splunk.exec }} edit cluster-master -old_master_uri {{ multisite_master_uri }} -site {{ splunk.site }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.pass4SymmKey }} -multisite True"
-  become: yes
-  become_user: "{{ splunk.user }}"
-  register: set_associated_site
-  until: set_associated_site.rc == 0 or (set_associated_site.rc == 22 and 'No change in master or secret or site.' in set_associated_site.stderr) or (set_associated_site.rc == 22 and 'No change in manager or secret or site.' in set_associated_site.stderr)
-  changed_when: set_associated_site.rc == 0
-  retries: "{{ retry_num }}"
-  delay: "{{ retry_delay }}"
-  ignore_errors: yes
-  notify:
-    - Restart the splunkd service
-  no_log: "{{ hide_password }}"
-  failed_when: set_associated_site.rc != 0 and ('No change in master or secret or site.' not in set_associated_site.stderr and 'No change in manager or secret or site.' not in set_associated_site.stderr)


### PR DESCRIPTION
This change in ansible will allow us to register multiple indexer clusters with the SH/MC if they are created in the cluster. 